### PR TITLE
Added temperature component

### DIFF
--- a/camel-temperature/src/main/java/io/silverspoon/TemperatureEndpoint.java
+++ b/camel-temperature/src/main/java/io/silverspoon/TemperatureEndpoint.java
@@ -1,8 +1,8 @@
 package io.silverspoon;
 
 import io.silverspoon.device.OneWireTemperatureSensor;
+import io.silverspoon.device.SPITemperatureSensor;
 import io.silverspoon.device.TemperatureSensor;
-
 import org.apache.camel.Consumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
@@ -24,6 +24,7 @@ public class TemperatureEndpoint extends DefaultEndpoint {
    private String type = null;
 
    private final String W1_DIR = System.getProperty("w1.devices", "/sys/bus/w1/devices/");
+   private final String SPI_MOSI_PIN = System.getProperty("SPI_MOSI", "P1_19");
 
    private List<TemperatureSensor> sensors = new ArrayList<TemperatureSensor>();
    private static final Logger LOG = Logger.getLogger(TemperatureEndpoint.class);
@@ -57,7 +58,6 @@ public class TemperatureEndpoint extends DefaultEndpoint {
    }
 
    private void loadSensors() {
-      // Load sensors (currently only w1 is supported)
       switch (type) {
          case "w1":
             loadW1Sensors();
@@ -73,14 +73,13 @@ public class TemperatureEndpoint extends DefaultEndpoint {
       }
    }
 
-   private void loadSPISensors() {
+   private void loadI2cSensors() {
       // TODO:
       throw new UnsupportedOperationException("Not implemented, yet.");
    }
 
-   private void loadI2cSensors() {
-      // TODO:
-      throw new UnsupportedOperationException("Not implemented, yet.");
+   private void loadSPISensors() {
+      sensors.add(new SPITemperatureSensor(SPI_MOSI_PIN));
    }
 
    private void loadW1Sensors() {

--- a/camel-temperature/src/main/java/io/silverspoon/device/SPITemperatureSensor.java
+++ b/camel-temperature/src/main/java/io/silverspoon/device/SPITemperatureSensor.java
@@ -1,0 +1,57 @@
+package io.silverspoon.device;
+
+import java.io.IOException;
+import java.util.List;
+
+import io.silverspoon.bulldog.core.gpio.DigitalOutput;
+import io.silverspoon.bulldog.core.io.bus.spi.SpiBus;
+import io.silverspoon.bulldog.core.io.bus.spi.SpiConnection;
+import io.silverspoon.bulldog.core.platform.Board;
+import io.silverspoon.bulldog.core.platform.Platform;
+import io.silverspoon.bulldog.devices.sensors.*;
+
+/**
+ * Represents SPI Temperature Sensor and reads its values.
+ *
+ * @author <a href="mailto:mat.per.vt@gmail.com">Matej Perejda</a>
+ */
+public class SPITemperatureSensor implements TemperatureSensor {
+
+   private final Board board;
+   private String SPI_MOSI;
+
+   private List<SpiBus> spiBuses;
+   private SpiBus spiBus;
+   private DigitalOutput output;
+   private SpiConnection connection;
+   private LM74TemperatureSensor temperatureSensorLM74;
+
+   /**
+    * Constructor
+    *
+    * @param pin
+    *       sets SPI MOSI pin defined by environment variable named "SPI_MOSI".
+    *       Default pin: "P1_19"
+    */
+   public SPITemperatureSensor(String pin) {
+         this.SPI_MOSI = pin;
+      // init board
+      board = Platform.createBoard();
+   }
+
+   @Override
+   public float readTemperature() throws IOException {
+      spiBuses = board.getSpiBuses();
+
+      spiBus = spiBuses.get(0);
+
+      output = board.getPin(SPI_MOSI).as(DigitalOutput.class);
+
+      connection = spiBus.createSpiConnection(output);
+
+      temperatureSensorLM74 = new LM74TemperatureSensor(connection, output);
+
+      return temperatureSensorLM74.readTemperature();
+   }
+
+}

--- a/camel-temperature/src/test/java/io/silverspoon/TemperatureComponentTest.java
+++ b/camel-temperature/src/test/java/io/silverspoon/TemperatureComponentTest.java
@@ -15,7 +15,9 @@ public class TemperatureComponentTest extends CamelTestSupport {
    
    @Produce(uri = "direct:start")
    protected ProducerTemplate template;
-   
+
+   // TODO: create test for SPI
+
    @Test
    public void testTemperature() throws Exception {
       resultEndpoint.expectedMinimumMessageCount(1);


### PR DESCRIPTION
Hi. I've added a support to camel-temperature component for **reading data over SPI** . A current implementation is based on **LM74TemperatureSensor** class in the Bulldog.
The component feature has not been tested so far, but it worked fine for me. 

UPDATE: **Travis actually fails due to missing LM74TemperatureSensor class in the current version of Bulldog in  pom.xml**